### PR TITLE
Fixed: config.yaml properties that are YAML objects are not displayed

### DIFF
--- a/src/config_get.py
+++ b/src/config_get.py
@@ -16,7 +16,7 @@ import os
 import src.read_config
 import src.tools
 
-def get(property):
+def get(property, comments = True):
     """Get a property to the current project
 
     Args:
@@ -44,8 +44,12 @@ def get(property):
         #If it was added correctly
         if(value_of_property != "null"):
             
+            value_of_property_str = src.tools.object_to_yaml_str(value_of_property).replace("...", "")
+            
+            if comments == False:
+                value_of_property_str = src.tools.stripComments(value_of_property_str)
             # Message(Successful): Getting property
-            src.tools.message_successful('Getting property ' + property + ': ' + str(value_of_property))
+            src.tools.message_successful('Getting property \n' + property + ': ' +  value_of_property_str)
             
         else:
             # Message(Error): Could not add

--- a/src/config_t.py
+++ b/src/config_t.py
@@ -48,10 +48,11 @@ class config_t:
         self.yaml.preserve_quotes = True
 
         #Read file
-        self.file = open( dir + "/config.yaml", "r")
+        self.file = dir + "/config.yaml"
 
         #Write Data
-        self._data = self.yaml.load(self.file)
+        #self._data = self.yaml.load(self.file)
+        self._data = src.tools.yaml_file_to_object(self.file)
 
     def print(self):
         """Print the src.config_t

--- a/src/main.py
+++ b/src/main.py
@@ -97,20 +97,12 @@ def clean():
 
 @main.command('get', short_help='Get property of current Next Project')
 @click.option('--property',default="name", required=True, help='Select property of current Next Project <default=name>')
-def get(property):
-    value_of_property = src.config_get.get(property)
-    if isinstance(value_of_property, list):
-        value_in_str = ''
-        value_in_str += '['
-        for x in value_of_property:
-            value_in_str += x + ','
-        len_value = len(value_in_str)
-        value_in_str = value_in_str[:len_value-1]
-        value_in_str += ']' 
-    else:
-        value_in_str = value_of_property
+@click.option('--comments',default=True, required=False, type=bool, help='Select name of build')
+def get(property, comments):
+    value_of_property = src.config_get.get(property, comments)
+
     
-    print(property + ": " + value_in_str)
+    #print(property + ": " + value_in_str)
 
 @main.command('set', short_help='Set property of current Next Project')
 @click.option('--property',default="name", required=True, help='Select property of current Next Project <default=name>')

--- a/src/tools.py
+++ b/src/tools.py
@@ -114,3 +114,50 @@ def absoluteFilePaths(directory):
     for dirpath,_,filenames in os.walk(directory):
         for f in filenames:
             yield os.path.abspath(os.path.join(dirpath, f))
+            
+
+import ruamel.yaml
+from io import StringIO
+from pathlib import Path
+
+# setup loader (basically options)
+yaml = ruamel.yaml.YAML()
+yaml.allow_duplicate_keys = True
+# show null
+def represent_of_null(self, data):
+    return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
+yaml.representer.add_representer(type(None), represent_of_null)
+
+# o->s
+def object_to_yaml_str(obj, options=None):
+    if options == None: options = {}
+    string_stream = StringIO()
+    #print("##################################")
+    yaml.dump(obj, string_stream, **options)
+    output_str = string_stream.getvalue()
+    string_stream.close()
+    return output_str
+
+# s->o
+def yaml_string_to_object(string, options=None):
+    if options == None: options = {}
+    return yaml.load(string, **options)
+
+# f->o
+def yaml_file_to_object(file_path, options=None):
+    if options == None: options = {}
+    as_path_object = Path(file_path)
+    return yaml.load(as_path_object, **options)
+
+# o->f
+def object_to_yaml_file(obj, file_path, options=None):
+    if options == None: options = {}
+    as_path_object = Path(Path(file_path))
+    with as_path_object.open('w') as output_file:
+        return yaml.dump(obj, output_file, **options)
+
+# Remove commnets of String
+import re
+def stripComments(code):
+    code = str(code)
+    return re.sub(r'(?m)^ *#.*\n?', '', code)


### PR DESCRIPTION

The problem of displaying objects in the 'next get' function has been fixed, and an option has been added to not display comments